### PR TITLE
Update to PureScript 0.11 & fix describe.only

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-spec-mocha",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-spec-mocha",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -18,5 +18,8 @@
   "dependencies": {
     "purescript-foldable-traversable": "^3.0.0",
     "purescript-spec": "^1.0.0"
+  },
+  "devDependencies": {
+    "purescript-datetime": "^3.3.0"
   }
 }

--- a/src/Test/Spec/Mocha.js
+++ b/src/Test/Spec/Mocha.js
@@ -36,7 +36,7 @@ exports.describe = function (only) {
     return function (name) {
         return function (nested) {
             return function () {
-                var f = only ? describe : describe.only;
+                var f = only ? describe.only : describe;
                 f(name, function () {
                     nested();
                 });

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,11 +1,12 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Aff (later')
+import Control.Monad.Aff (delay)
 import Control.Monad.Eff (Eff)
 import Test.Spec (SpecEffects, describe, it, pending)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Mocha (MOCHA, runMocha)
+import Data.Time.Duration(Milliseconds(..))
 
 main :: Eff (SpecEffects (mocha :: MOCHA)) Unit
 main = runMocha do
@@ -21,8 +22,10 @@ main = runMocha do
 
   describe "async" do
     it "works" $ do
-      expected <- later' 1000 (pure 2)
+      delay $ Milliseconds 1000.0
+      expected <- pure 2
       (1 + 1) `shouldEqual` expected
     it "and can fail" do
-      expected <- later' 1000 (pure 3)
+      delay $ Milliseconds 1000.0
+      expected <- pure 3
       (1 + 1) `shouldEqual` expected


### PR DESCRIPTION
Sorry, PR coming a bit late, I kinda forgot about it. 

I've updated the module to PS 0.11 (but I see that it has also been done by someone else in the meantime). This PR still fixes an issue with the order of evaluation of the `describe.only` feature. 

I'll rebase this on top of the current master to keep only the relevant changes.