### PR TITLE
Update for purescript-spec v4 api

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "purescript-console": "^4.0.0",
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-exceptions": "^4.0.0",
-    "purescript-spec": "^3.0.0"
+    "purescript-spec": "^4.0.0"
   }
 }


### PR DESCRIPTION
I've only tested by running the test in `test/Main.purs`. It outputs
```
  ✓ works
  - is pending
  1) breaks
  ✓ works
  2) and can fail

  2 passing (12ms)
  1 pending
  2 failing

  1) breaks:
     Error: 1 ≠ 2
      at Object.exports.error (output.js:2101:12)
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:2263:39
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:2271:148
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:2372:358
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:501:32
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:791:16
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:791:18
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:791:22
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:791:18
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:791:22
      at Object.main (output.js:791:18)
      at Object.<anonymous> (output.js:2388:17)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)
      at Module.require (internal/modules/cjs/loader.js:637:17)
      at require (internal/modules/cjs/helpers.js:20:18)
      at Array.forEach (<anonymous>)
      at Module._compile (internal/modules/cjs/loader.js:689:30)
      at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
      at Module.load (internal/modules/cjs/loader.js:599:32)
      at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
      at Function.Module._load (internal/modules/cjs/loader.js:530:3)
      at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
      at startup (internal/bootstrap/node.js:266:19)
      at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)

  2) and can fail:
     Error: 2 ≠ 3
      at Object.exports.error (output.js:2101:12)
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:2263:39
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:2271:148
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:2381:129
      at run (output.js:1104:22)
      at /Users/johncarlosanpedro/projects/purescript-spec-mocha/output.js:1169:21
      at drain (output.js:947:11)
      at Object.enqueue (output.js:968:13)
      at Timeout._onTimeout (output.js:1160:29)



FAIL: 2
```

I think that seems right?